### PR TITLE
Add FeatureFlag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,6 +7,7 @@ enum FeatureFlag: Int {
     case saveForLater
     case gifSupportInReaderDetail
     case extractNotifications
+    case automatedTransfersCustomDomain
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -20,6 +21,8 @@ enum FeatureFlag: Int {
         case .gifSupportInReaderDetail:
             return true
         case .extractNotifications:
+            return BuildConfiguration.current == .localDeveloper
+        case .automatedTransfersCustomDomain:
             return BuildConfiguration.current == .localDeveloper
         }
     }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/9630

A new FeatureFlag is added named automatedTransfersCustomDomain to limit the availability of this feature.

To test:-


