### PR TITLE
Update visibility criteria of Plugins option

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -558,7 +558,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     if ([Feature enabled:FeatureFlagAutomatedTransfersCustomDomain]) {
         return self.isHostedAtWPcom
         && self.planID.integerValue == BusinessPlanId
-        && !(self.siteVisibility == SiteVisibilityPrivate)
+        && self.siteVisibility != SiteVisibilityPrivate
         && self.isAdmin;
     } else {
         return [self hasRequiredJetpackVersion:@"5.6"];

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -18,6 +18,7 @@ static NSInteger const ImageSizeLargeWidth = 640;
 static NSInteger const ImageSizeLargeHeight = 480;
 static NSInteger const JetpackProfessionalYearlyPlanId = 2004;
 static NSInteger const JetpackProfessionalMonthlyPlanId = 2001;
+static NSInteger const BusinessPlanId = 1008;
 
 NSString * const BlogEntityName = @"Blog";
 NSString * const PostFormatStandard = @"standard";
@@ -554,7 +555,14 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 
 - (BOOL)supportsPluginManagement
 {
-    return [self hasRequiredJetpackVersion:@"5.6"];
+    if ([Feature enabled:FeatureFlagAutomatedTransfersCustomDomain]) {
+        return self.isHostedAtWPcom
+        && self.planID.integerValue == BusinessPlanId
+        && !(self.siteVisibility == SiteVisibilityPrivate)
+        && self.isAdmin;
+    } else {
+        return [self hasRequiredJetpackVersion:@"5.6"];
+    }
 }
 
 - (BOOL)accountIsDefaultAccount


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/9630

Visibility criteria of Plugins option is updated in site details. Following criteria are checked:

1. It is a WordPress.com site
2. It has a business plan
3. It is not private
4. The user has admin rights for the site (we are currently checking the manage options capability)

Before this change the condition here was only checking if the site has JetPack 5.6.

To test: 
Precondition: having a site with the above 4 criteria.
1. Open My Sites
2. Tap on the site having these 4 criteria
3. See that CONFIGURE section has Plugins option between People and Settings.
4. Tap on Plugins and see that Plugins page opens



